### PR TITLE
add custom texts to userOptions

### DIFF
--- a/src/Search.vue
+++ b/src/Search.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, onMounted, nextTick } from 'vue';
+import { ref, onMounted, nextTick, computed } from 'vue';
 
 type FileSearchData = Array<{ title: string; content: string; link: string }>;
 
@@ -12,6 +12,17 @@ const searchResults = ref<FileSearchData>([]);
 const lastTimeoutID = ref<number | undefined>(undefined);
 const msToSearch = ref<number>(0);
 const regexForContentStripping = ref<RegExp>(/[\W_]+/g);
+
+const placeholderText = ref('Search. Use double quotes for stricter results.');
+const searchText = ref('Search...');
+const noResultsText = ref('No results found.');
+const searchTimeText = ref('{time}ms for {count} results');
+
+const searchTime = computed(() => {
+    return searchTimeText.value
+        .replace('{time}', msToSearch.value.toString())
+        .replace('{count}', searchResults.value.length.toString());
+});
 
 const debounce = (callback: Function, wait: number) => {
     if (typeof lastTimeoutID.value !== 'undefined') {
@@ -139,6 +150,10 @@ onMounted(async () => {
         fileData.value = importData.default.data;
         searchResults.value = importData.default.data;
         regexForContentStripping.value = importData.default.regexForContentStripping;
+        searchText.value = importData.default.searchText;
+        placeholderText.value = importData.default.placeholderText;
+        noResultsText.value = importData.default.noResultsText;
+        searchTimeText.value = importData.default.searchTimeText;
     } catch (err) {
         console.log(`Could not load search data from virtual module.`);
         console.log(`Maybe search data includes malformed data?`);
@@ -161,7 +176,7 @@ onMounted(async () => {
                             @input="trySearch"
                             v-model="searchData"
                             class="search-input"
-                            placeholder="Search. Use double quotes for stricter results."
+                            :placeholder="placeholderText"
                             aria-autocomplete="both"
                             autocomplete="off"
                             autocorrect="off"
@@ -177,7 +192,7 @@ onMounted(async () => {
                     </div>
                     <div class="search-results">
                         <div v-if="searchResults.length >= 1">
-                            <div class="search-time">{{ msToSearch }}ms for {{ searchResults.length }} Results</div>
+                            <div class="search-time">{{ searchTime }}</div>
                             <a
                                 class="result"
                                 v-for="(result, index) in searchResults"
@@ -196,13 +211,13 @@ onMounted(async () => {
                                 </div>
                             </a>
                         </div>
-                        <div v-else>No Results</div>
+                        <div v-else>{{ noResultsText }}</div>
                     </div>
                 </div>
             </div>
         </Teleport>
         <div class="search">
-            <div class="search-text" @click="openSearch()">Search...</div>
+            <div class="search-text" @click="openSearch()">{{ searchText }}</div>
         </div>
     </div>
 </template>

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,14 +44,23 @@ export function SimpleSearch(userOptions: Options): Plugin {
                 }
 
                 const fileData = await buildDocumentation(config.root, userOptions.preambleTransformer);
-                const javaScript: string =
-                    `const regexForContentStripping = ${options.regexForContentStripping}` +
-                    ';\n' +
-                    'const data =' +
-                    JSON.stringify(fileData) +
-                    ';\n' +
-                    'export default { data, regexForContentStripping };';
 
+                const javaScript: string =
+                    `const regexForContentStripping = ${options.regexForContentStripping};
+                    const data = ${JSON.stringify(fileData)};
+                    const searchText = "${options.searchText}";
+                    const placeholderText = "${options.placeholderText}";
+                    const noResultsText = "${options.noResultsText}";
+                    const searchTimeText = "${options.searchTimeText}";
+                    export default { 
+                        data, 
+                        regexForContentStripping, 
+                        searchText, 
+                        placeholderText, 
+                        noResultsText, 
+                        searchTimeText 
+                    };`;
+                    
                 return javaScript;
             }
         },

--- a/src/interfaces/options.ts
+++ b/src/interfaces/options.ts
@@ -41,4 +41,40 @@ export interface Options {
      * @memberof Options
      */
     preambleTransformer?: ((data: { [key: string]: any }) => { [key: string]: any }) | undefined;
+
+    /**
+     * Search text on navbar.
+     * 
+     * @default 'Search...'
+     * @type string
+     * @memberof Options
+     */
+    searchText?: string;
+
+    /**
+     * Placeholder text on search input.
+     * 
+     * @default 'Search. Use double quotes for stricter results.'
+     * @type string
+     * @memberof Options
+     */
+    placeholderText?: string;
+
+    /**
+     * Text to display when no results are found.
+     * 
+     * @default 'No results found.'
+     * @type string
+     * @memberof Options
+     */
+    noResultsText?: string;
+
+    /**
+     * Text to display when search is complete.
+     * 
+     * @default '{time}ms for {count} results'
+     * @type string
+     * @memberof Options
+     */     
+    searchTimeText?: string;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -4,6 +4,10 @@ let options: Options = {
     baseURL: '',
     regexForContentStripping: /[^a-zA-Z0-9._ ]+/g,
     preambleTransformer: undefined, // No transformation
+    searchText: 'Search...',
+    placeholderText: 'Search. Use double quotes for stricter results.',
+    noResultsText: 'No results found.',
+    searchTimeText: '{time}ms for {count} results',
 };
 
 /**

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -7,5 +7,16 @@ declare module '*.vue' {
 declare module 'virtual:simple-search' {
     const regexForContentStripping: RegExp;
     const data: Array<{ title: string; content: string; link: string }>;
-    export default { data, regexForContentStripping };
+    const searchText: string;
+    const placeholderText: string;
+    const noResultsText: string;
+    const searchTimeText: string;
+    export default {
+        data,
+        regexForContentStripping,
+        searchText,
+        placeholderText,
+        noResultsText,
+        searchTimeText,
+    };
 }


### PR DESCRIPTION
Adding options to customize texts

```ts
export interface Options {
    [...],

    /**
     * Search text on navbar.
     * 
     * @default 'Search...'
     * @type string
     * @memberof Options
     */
    searchText?: string;

    /**
     * Placeholder text on search input.
     * 
     * @default 'Search. Use double quotes for stricter results.'
     * @type string
     * @memberof Options
     */
    placeholderText?: string;

    /**
     * Text to display when no results are found.
     * 
     * @default 'No results found.'
     * @type string
     * @memberof Options
     */
    noResultsText?: string;

    /**
     * Text to display when search is complete.
     * 
     * @default '{time}ms for {count} results'
     * @type string
     * @memberof Options
     */     
    searchTimeText?: string;
}
```

close #17 